### PR TITLE
refactor!: drop support for helm2, update labels, support v1 Ingress

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -5,3 +5,4 @@ chart-dirs:
 chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout 600s
+target-branch: main

--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,11 +1,18 @@
-apiVersion: v1
+apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 2.16.0
+version: 3.0.0
 appVersion: 0.13.0
-home: https://github.com/helm/chartmuseum
-icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg 
+home: https://github.com/chartmuseum
+icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg
 keywords:
-- chartmuseum
-- helm
-- charts repo
+  - chartmuseum
+  - helm
+  - charts repo
+sources:
+  - https://github.com/chartmuseum/charts/tree/main/src/chartmuseum
+  - https://github.com/chartmuseum
+  - https://github.com/helm/chartmuseum
+maintainers:
+  - name: chartmuseum
+    url: https://github.com/chartmuseum

--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -3,7 +3,7 @@ description: Host your own Helm Chart Repository
 name: chartmuseum
 version: 3.0.0
 appVersion: 0.13.0
-home: https://github.com/chartmuseum
+home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg
 keywords:
   - chartmuseum

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -39,6 +39,8 @@ Please also see https://github.com/helm/chartmuseum
       - [Annotations](#annotations)
       - [Example Ingress configuration](#example-ingress-configuration)
   - [Uninstall](#uninstall)
+  - [Upgrading](#upgrading)
+    - [To 3.0.0](#to-300)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -749,3 +751,13 @@ To delete the deployment and its history:
 ```shell
 helm delete --purge my-chartmuseum
 ```
+
+## Upgrading
+
+### To 3.0.0
+
+* This is a breaking change which only supports Helm v3.0.0+ now. If you still use helm v2, please consider upgrading because v2 is EOL for quite a while.  
+  * To migrate to helm v3 please have a look at the [Helm 2to3 Plugin](https://github.com/helm/helm-2to3). This tool will convert the existing ConfigMap used for Tiller to a Secret of type `helm.sh/release.v1`.
+  * When you are using object storage for persistence (instead of a PVC), you can simply uninstall your helm v2 release and perform a fresh installation with helm v3 without using the `2to3` plugin.
+* We now follow the official Kubernetes [label recommendations](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).  
+  To upgrade an existing installation, please **add the `--force` parameter** to the `helm upgrade` command or **delete the Deployment resource** before you upgrade. This is necessary becase Deployment's label selector is immutable.

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -92,13 +92,10 @@ their default values. See values.yaml for all available options.
 | `volumePermissions.image.tag`           | Init container volume-permissions image tag                                 | `buster`                             |
 | `volumePermissions.image.pullPolicy`    | Init container volume-permissions image pull policy                         | `Always`                             |
 | `replicaCount`                          | k8s replicas                                                                | `1`                                  |
-| `resources.limits.cpu`                  | Container maximum CPU                                                       | `100m`                               |
-| `resources.limits.memory`               | Container maximum memory                                                    | `128Mi`                              |
-| `resources.requests.cpu`                | Container requested CPU                                                     | `80m`                                |
-| `resources.requests.memory`             | Container requested memory                                                  | `64Mi`                               |
-| `secret.labels`                         | Additional labels for secret                                                | `false`                              |
+| `resources`                             | CPU/Memory resource requests and limits                                     | `{}`                                 |
+| `secret.labels`                         | Additional labels for secret                                                | `{}`                                 |
 | `serviceAccount.create`                 | If true, create the service account                                         | `false`                              |
-| `serviceAccount.name`                   | Name of the serviceAccount to create or use                                 | `{{ chartmuseum.fullname }}`         |
+| `serviceAccount.name`                   | Name of the serviceAccount to create or use                                 | `""`                                 |
 | `serviceAccount.annotations`            | Additional Service Account annotations                                      | `{}`                                 |
 | `securityContext.enabled`               | Enable securityContext                                                      | `true`                               |
 | `securityContext.fsGroup`               | Group ID for the container                                                  | `1000`                               |
@@ -109,7 +106,7 @@ their default values. See values.yaml for all available options.
 | `nodeSelector`                          | Map of node labels for pod assignment                                       | `{}`                                 |
 | `tolerations`                           | List of node taints to tolerate                                             | `[]`                                 |
 | `affinity`                              | Map of node/pod affinities                                                  | `{}`                                 |
-| `schedulerName`                         | Kubernetes scheduler to use                                                 | `default`                            |
+| `schedulerName`                         | Kubernetes scheduler to use                                                 | `<nil>` (Uses default scheduler)     |
 | `env.open.STORAGE`                      | Storage Backend to use                                                      | `local`                              |
 | `env.open.STORAGE_ALIBABA_BUCKET`       | Bucket to store charts in for Alibaba                                       | ``                                   |
 | `env.open.STORAGE_ALIBABA_PREFIX`       | Prefix to store charts under for Alibaba                                    | ``                                   |
@@ -150,14 +147,14 @@ their default values. See values.yaml for all available options.
 | `env.open.BEARER_AUTH`                  | Enable bearer auth                                                          | `false`                              |
 | `env.open.AUTH_REALM`                   | Realm used for bearer authentication                                        | ``                                   |
 | `env.open.AUTH_SERVICE`                 | Service used for bearer authentication                                      | ``                                   |
-| `env.field`                             | Expose pod information to containers through environment variables          | ``                                   |
+| `env.field`                             | Expose pod information to containers through environment variables          | `{}`                                 |
 | `env.existingSecret`                    | Name of the existing secret use values                                      | ``                                   |
 | `env.existingSecret.BASIC_AUTH_USER`    | Key name in the secret for the Username                                     | ``                                   |
 | `env.existingSecret.BASIC_AUTH_PASS`    | Key name in the secret for the Password                                     | ``                                   |
 | `env.secret.BASIC_AUTH_USER`            | Username for basic HTTP authentication                                      | ``                                   |
 | `env.secret.BASIC_AUTH_PASS`            | Password for basic HTTP authentication                                      | ``                                   |
 | `env.secret.CACHE_REDIS_PASSWORD`       | Redis requirepass server configuration                                      | ``                                   |
-| `extraArgs`                             | Pass extra arguments to the chartmuseum binary                              | ``                                   |
+| `extraArgs`                             | Pass extra arguments to the chartmuseum binary                              | `[]`                                 |
 | `gcp.secret.enabled`                    | Flag for the GCP service account                                            | `false`                              |
 | `gcp.secret.name`                       | Secret name for the GCP json file                                           | ``                                   |
 | `gcp.secret.key`                        | Secret key for te GCP json file                                             | `credentials.json`                   |
@@ -180,10 +177,10 @@ their default values. See values.yaml for all available options.
 | `serviceMonitor.interval`               | Scrape interval, If not set, the Prometheus default scrape interval is used | `nil`                                |
 | `serviceMonitor.timeout`                | Scrape request timeout. If not set, the Prometheus default timeout is used  | `nil`                                |
 | `deployment.labels`                     | Additional labels for deployment                                            | `{}`                                 |
-| `deployment.matchlabes`                 | Match labels for deployment selector                                        | `{}`                                 |
+| `podAnnotations`                        | Annotations for pods                                                        | `{}`                                 |
 | `ingress.enabled`                       | Enable ingress controller resource                                          | `false`                              |
-| `ingress.annotations`                   | Ingress annotations                                                         | `[]`                                 |
-| `ingress.labels`                        | Ingress labels                                                              | `[]`                                 |
+| `ingress.annotations`                   | Ingress annotations                                                         | `{}`                                 |
+| `ingress.labels`                        | Ingress labels                                                              | `{}`                                 |
 | `ingress.hosts[0].name`                 | Hostname for the ingress                                                    | ``                                   |
 | `ingress.hosts[0].path`                 | Path within the url structure                                               | ``                                   |
 | `ingress.hosts[0].tls `                 | Enable TLS on the ingress host                                              | `false`                              |
@@ -295,9 +292,8 @@ env:
     STORAGE_AMAZON_BUCKET: my-s3-bucket
     STORAGE_AMAZON_PREFIX:
     STORAGE_AMAZON_REGION: us-east-1
-replica:
-  annotations:
-    iam.amazonaws.com/role: "{assumed role name}"
+podAnnotations:
+  iam.amazonaws.com/role: "{assumed role name}"
 ```
 
 Run command to install

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -761,3 +761,6 @@ helm delete --purge my-chartmuseum
   * When you are using object storage for persistence (instead of a PVC), you can simply uninstall your helm v2 release and perform a fresh installation with helm v3 without using the `2to3` plugin.
 * We now follow the official Kubernetes [label recommendations](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).  
   To upgrade an existing installation, please **add the `--force` parameter** to the `helm upgrade` command or **delete the Deployment resource** before you upgrade. This is necessary becase Deployment's label selector is immutable.
+* Renamed parameters
+  * `deployment.schedulerName` was renamed to `schedulerName`
+  * `replica.annotations` was renamed to `podAnnotations`

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -45,6 +45,7 @@ Please also see https://github.com/helm/chartmuseum
 
 ## Prerequisites
 
+* Helm v3.0.0+
 * [If enabled] A persistent storage resource and RW access to it
 * [If enabled] Kubernetes StorageClass for dynamic provisioning
 
@@ -79,14 +80,14 @@ their default values. See values.yaml for all available options.
 | `persistence.path`                      | PV mount path                                                               | `/storage`                           |
 | `persistence.size`                      | Amount of space to claim for PVC                                            | `8Gi`                                |
 | `persistence.labels`                    | Additional labels for PVC                                                   | `{}`                                 |
-| `persistence.storageClass`              | Storage Class to use for PVC                                                | `-`                                  |
-| `persistence.volumeName`                | Volume to use for PVC                                                       | ``                                   |
+| `persistence.storageClass`              | Storage Class to use for PVC                                                | `undefined` (Uses default provisioner)|
+| `persistence.volumeName`                | Volume to use for PVC                                                       | `undefined`                          |
 | `persistence.pv.enabled`                | Whether to use a PV for persistent storage                                  | `false`                              |
 | `persistence.pv.capacity.storage`       | Storage size to use for PV                                                  | `8Gi`                                |
 | `persistence.pv.accessMode`             | Access mode to use for PV                                                   | `ReadWriteOnce`                      |
-| `persistence.pv.nfs.server`             | NFS server for PV                                                           | ``                                   |
-| `persistence.pv.nfs.path`               | Storage Path                                                                | ``                                   |
-| `persistence.pv.pvname`                 | Custom name for private volume                                              | ``                                   |
+| `persistence.pv.nfs.server`             | NFS server for PV                                                           | `<nil>`                              |
+| `persistence.pv.nfs.path`               | Storage Path                                                                | `<nil>`                              |
+| `persistence.pv.pvname`                 | Custom name for private volume                                              | `<nil>`                              |
 | `volumePermissions.image.registry`      | Init container volume-permissions image registry                            | `docker.io`                          |
 | `volumePermissions.image.repository`    | Init container volume-permissions image name                                | `bitnami/minideb`                    |
 | `volumePermissions.image.tag`           | Init container volume-permissions image tag                                 | `buster`                             |
@@ -99,37 +100,37 @@ their default values. See values.yaml for all available options.
 | `serviceAccount.annotations`            | Additional Service Account annotations                                      | `{}`                                 |
 | `securityContext.enabled`               | Enable securityContext                                                      | `true`                               |
 | `securityContext.fsGroup`               | Group ID for the container                                                  | `1000`                               |
-| `securityContext.runAsNonRoot`          | Running Pods as non-root                                                    | ``                                   |
-| `securityContext.supplementalGroups`    | Control which group IDs containers add                                      | ``                                   |
-| `containerSecurityContext`              | Additional Container securityContext (ex. allowPrivilegeEscalation)         | `{}`                                 |
+| `securityContext.runAsNonRoot`          | Running Pods as non-root                                                    | `undefined`                          |
+| `securityContext.supplementalGroups`    | Control which group IDs containers add                                      | `undefined`                          |
+| `containerSecurityContext`              | Additional Container securityContext (e.g. allowPrivilegeEscalation)        | `{}`                                 |
 | `priorityClassName      `               | priorityClassName                                                           | `""`                                 |
 | `nodeSelector`                          | Map of node labels for pod assignment                                       | `{}`                                 |
 | `tolerations`                           | List of node taints to tolerate                                             | `[]`                                 |
 | `affinity`                              | Map of node/pod affinities                                                  | `{}`                                 |
 | `schedulerName`                         | Kubernetes scheduler to use                                                 | `<nil>` (Uses default scheduler)     |
 | `env.open.STORAGE`                      | Storage Backend to use                                                      | `local`                              |
-| `env.open.STORAGE_ALIBABA_BUCKET`       | Bucket to store charts in for Alibaba                                       | ``                                   |
-| `env.open.STORAGE_ALIBABA_PREFIX`       | Prefix to store charts under for Alibaba                                    | ``                                   |
-| `env.open.STORAGE_ALIBABA_ENDPOINT`     | Alternative Alibaba endpoint                                                | ``                                   |
-| `env.open.STORAGE_ALIBABA_SSE`          | Server side encryption algorithm to use                                     | ``                                   |
-| `env.open.STORAGE_AMAZON_BUCKET`        | Bucket to store charts in for AWS                                           | ``                                   |
-| `env.open.STORAGE_AMAZON_ENDPOINT`      | Alternative AWS endpoint                                                    | ``                                   |
-| `env.open.STORAGE_AMAZON_PREFIX`        | Prefix to store charts under for AWS                                        | ``                                   |
-| `env.open.STORAGE_AMAZON_REGION`        | Region to use for bucket access for AWS                                     | ``                                   |
-| `env.open.STORAGE_AMAZON_SSE`           | Server side encryption algorithm to use                                     | ``                                   |
-| `env.open.STORAGE_GOOGLE_BUCKET`        | Bucket to store charts in for GCP                                           | ``                                   |
-| `env.open.STORAGE_GOOGLE_PREFIX`        | Prefix to store charts under for GCP                                        | ``                                   |
-| `env.open.STORAGE_MICROSOFT_CONTAINER`  | Container to store charts under for MS                                      | ``                                   |
-| `env.open.STORAGE_MICROSOFT_PREFIX`     | Prefix to store charts under for MS                                         | ``                                   |
-| `env.open.STORAGE_OPENSTACK_CONTAINER`  | Container to store charts for openstack                                     | ``                                   |
-| `env.open.STORAGE_OPENSTACK_PREFIX`     | Prefix to store charts for openstack                                        | ``                                   |
-| `env.open.STORAGE_OPENSTACK_REGION`     | Region of openstack container                                               | ``                                   |
-| `env.open.STORAGE_OPENSTACK_CACERT`     | Path to a CA cert bundle for openstack                                      | ``                                   |
-| `env.open.STORAGE_ORACLE_COMPARTMENTID` | Compartment ID for Oracle Object Store                                      | ``                                   |
-| `env.open.STORAGE_ORACLE_BUCKET`        | Bucket to store charts in Oracle Object Store                               | ``                                   |
-| `env.open.STORAGE_ORACLE_PREFIX`        | Prefix to store charts for Oracle object Store                              | ``                                   |
-| `env.open.CHART_POST_FORM_FIELD_NAME`   | Form field to query for chart file content                                  | ``                                   |
-| `env.open.PROV_POST_FORM_FIELD_NAME`    | Form field to query for chart provenance                                    | ``                                   |
+| `env.open.STORAGE_ALIBABA_BUCKET`       | Bucket to store charts in for Alibaba                                       | `<nil>`                              |
+| `env.open.STORAGE_ALIBABA_PREFIX`       | Prefix to store charts under for Alibaba                                    | `<nil>`                              |
+| `env.open.STORAGE_ALIBABA_ENDPOINT`     | Alternative Alibaba endpoint                                                | `<nil>`                              |
+| `env.open.STORAGE_ALIBABA_SSE`          | Server side encryption algorithm to use                                     | `<nil>`                              |
+| `env.open.STORAGE_AMAZON_BUCKET`        | Bucket to store charts in for AWS                                           | `<nil>`                              |
+| `env.open.STORAGE_AMAZON_ENDPOINT`      | Alternative AWS endpoint                                                    | `<nil>`                              |
+| `env.open.STORAGE_AMAZON_PREFIX`        | Prefix to store charts under for AWS                                        | `<nil>`                              |
+| `env.open.STORAGE_AMAZON_REGION`        | Region to use for bucket access for AWS                                     | `<nil>`                              |
+| `env.open.STORAGE_AMAZON_SSE`           | Server side encryption algorithm to use                                     | `<nil>`                              |
+| `env.open.STORAGE_GOOGLE_BUCKET`        | Bucket to store charts in for GCP                                           | `<nil>`                              |
+| `env.open.STORAGE_GOOGLE_PREFIX`        | Prefix to store charts under for GCP                                        | `<nil>`                              |
+| `env.open.STORAGE_MICROSOFT_CONTAINER`  | Container to store charts under for MS                                      | `<nil>`                              |
+| `env.open.STORAGE_MICROSOFT_PREFIX`     | Prefix to store charts under for MS                                         | `<nil>`                              |
+| `env.open.STORAGE_OPENSTACK_CONTAINER`  | Container to store charts for openstack                                     | `<nil>`                              |
+| `env.open.STORAGE_OPENSTACK_PREFIX`     | Prefix to store charts for openstack                                        | `<nil>`                              |
+| `env.open.STORAGE_OPENSTACK_REGION`     | Region of openstack container                                               | `<nil>`                              |
+| `env.open.STORAGE_OPENSTACK_CACERT`     | Path to a CA cert bundle for openstack                                      | `<nil>`                              |
+| `env.open.STORAGE_ORACLE_COMPARTMENTID` | Compartment ID for Oracle Object Store                                      | `<nil>`                              |
+| `env.open.STORAGE_ORACLE_BUCKET`        | Bucket to store charts in Oracle Object Store                               | `<nil>`                              |
+| `env.open.STORAGE_ORACLE_PREFIX`        | Prefix to store charts for Oracle object Store                              | `<nil>`                              |
+| `env.open.CHART_POST_FORM_FIELD_NAME`   | Form field to query for chart file content                                  | `chart`                              |
+| `env.open.PROV_POST_FORM_FIELD_NAME`    | Form field to query for chart provenance                                    | `prov`                               |
 | `env.open.DEPTH`                        | levels of nested repos for multitenancy.                                    | `0`                                  |
 | `env.open.DEBUG`                        | Show debug messages                                                         | `false`                              |
 | `env.open.LOG_JSON`                     | Output structured logs in JSON                                              | `true`                               |
@@ -137,59 +138,73 @@ their default values. See values.yaml for all available options.
 | `env.open.DISABLE_METRICS`              | Disable Prometheus metrics                                                  | `true`                               |
 | `env.open.DISABLE_API`                  | Disable all routes prefixed with /api                                       | `true`                               |
 | `env.open.ALLOW_OVERWRITE`              | Allow chart versions to be re-uploaded                                      | `false`                              |
-| `env.open.CHART_URL`                    | Absolute url for .tgzs in index.yaml                                        | ``                                   |
+| `env.open.CHART_URL`                    | Absolute url for .tgzs in index.yaml                                        | `<nil>`                              |
 | `env.open.AUTH_ANONYMOUS_GET`           | Allow anon GET operations when auth is used                                 | `false`                              |
-| `env.open.CONTEXT_PATH`                 | Set the base context path                                                   | ``                                   |
-| `env.open.INDEX_LIMIT`                  | Parallel scan limit for the repo indexer                                    | ``                                   |
-| `env.open.CACHE`                        | Cache store, can be one of: redis                                           | ``                                   |
-| `env.open.CACHE_REDIS_ADDR`             | Address of Redis service (host:port)                                        | ``                                   |
+| `env.open.CONTEXT_PATH`                 | Set the base context path                                                   | `<nil>`                              |
+| `env.open.INDEX_LIMIT`                  | Parallel scan limit for the repo indexer                                    | `0`                                  |
+| `env.open.CACHE`                        | Cache store, can be one of: redis                                           | `<nil>`                              |
+| `env.open.CACHE_REDIS_ADDR`             | Address of Redis service (host:port)                                        | `<nil>`                              |
 | `env.open.CACHE_REDIS_DB`               | Redis database to be selected after connect                                 | `0`                                  |
 | `env.open.BEARER_AUTH`                  | Enable bearer auth                                                          | `false`                              |
-| `env.open.AUTH_REALM`                   | Realm used for bearer authentication                                        | ``                                   |
-| `env.open.AUTH_SERVICE`                 | Service used for bearer authentication                                      | ``                                   |
+| `env.open.AUTH_REALM`                   | Realm used for bearer authentication                                        | `<nil>`                              |
+| `env.open.AUTH_SERVICE`                 | Service used for bearer authentication                                      | `<nil>`                              |
 | `env.field`                             | Expose pod information to containers through environment variables          | `{}`                                 |
-| `env.existingSecret`                    | Name of the existing secret use values                                      | ``                                   |
-| `env.existingSecret.BASIC_AUTH_USER`    | Key name in the secret for the Username                                     | ``                                   |
-| `env.existingSecret.BASIC_AUTH_PASS`    | Key name in the secret for the Password                                     | ``                                   |
-| `env.secret.BASIC_AUTH_USER`            | Username for basic HTTP authentication                                      | ``                                   |
-| `env.secret.BASIC_AUTH_PASS`            | Password for basic HTTP authentication                                      | ``                                   |
-| `env.secret.CACHE_REDIS_PASSWORD`       | Redis requirepass server configuration                                      | ``                                   |
+| `env.existingSecret`                    | Name of the existing secret use values                                      | `<nil>`                              |
+| `env.existingSecretMappings.BASIC_AUTH_USER`         | Key name in the secret for the Username                        | `<nil>`                              |
+| `env.existingSecretMappings.BASIC_AUTH_PASS`         | Key name in the secret for the Password                        | `<nil>`                              |
+| `env.existingSecretMappings.GOOGLE_CREDENTIALS_JSON` | Key name in the secret for the GCP service account json file   | `<nil>`                              |
+| `env.existingSecretMappings.CACHE_REDIS_PASSWORD`    | Key name in the secret for the Redis requirepass configuration | `<nil>`                              |
+| `env.secret.BASIC_AUTH_USER`            | Username for basic HTTP authentication                                      | `<nil>`                              |
+| `env.secret.BASIC_AUTH_PASS`            | Password for basic HTTP authentication                                      | `<nil>`                              |
+| `env.secret.GOOGLE_CREDENTIALS_JSON`    | GCP service account json file                                               | `<nil>`                              |
+| `env.secret.CACHE_REDIS_PASSWORD`       | Redis requirepass server configuration                                      | `<nil>`                              |
 | `extraArgs`                             | Pass extra arguments to the chartmuseum binary                              | `[]`                                 |
+| `probes.liveness.initialDelaySeconds`   | Delay before liveness probe is initiated                                    | `5`                                  |
+| `probes.liveness.periodSeconds`         | How often (in seconds) to perform the liveness probe                        | `10`                                 |
+| `probes.liveness.timeoutSeconds`        | Number of seconds after which the liveness probe times out                  | `1`                                  |
+| `probes.liveness.successThreshold`      | Minimum consecutive successes for the liveness probe                        | `1`                                  |
+| `probes.liveness.failureThreshold`      | Minimum consecutive failures for the liveness probe                         | `3`                                  |
+| `probes.readiness.initialDelaySeconds`  | Delay before readiness probe is initiated                                   | `5`                                  |
+| `probes.readiness.periodSeconds`        | How often (in seconds) to perform the readiness probe                       | `10`                                 |
+| `probes.readiness.timeoutSeconds`       | Number of seconds after which the readiness probe times out                 | `1`                                  |
+| `probes.readiness.successThreshold`     | Minimum consecutive successes for the readiness probe                       | `1`                                  |
+| `probes.readiness.failureThreshold`     | Minimum consecutive failures for the readiness probe                        | `3`                                  |
 | `gcp.secret.enabled`                    | Flag for the GCP service account                                            | `false`                              |
-| `gcp.secret.name`                       | Secret name for the GCP json file                                           | ``                                   |
+| `gcp.secret.name`                       | Secret name for the GCP json file                                           | `<nil>`                              |
 | `gcp.secret.key`                        | Secret key for te GCP json file                                             | `credentials.json`                   |
 | `oracle.secret.enabled`                 | Flag for Oracle OCI account                                                 | `false`                              |
-| `oracle.secret.name`                    | Secret name for OCI config and key                                          | ``                                   |
+| `oracle.secret.name`                    | Secret name for OCI config and key                                          | `<nil>`                              |
 | `oracle.secret.config`                  | Secret key that holds the OCI config                                        | `config`                             |
 | `oracle.secret.key_file`                | Secret key that holds the OCI private key                                   | `key_file`                           |
-| `bearerAuth.secret.enabled`             | Flag for bearer auth public key secret                                      | ``                                   |
-| `bearerAuth.secret.publicKey`           | The name of the secret with the public key                                  | ``                                   |
+| `bearerAuth.secret.enabled`             | Flag for bearer auth public key secret                                      | `false`                              |
+| `bearerAuth.secret.publicKeySecret`     | The name of the secret with the public key                                  | `chartmuseum-public-key`             |
 | `service.type`                          | Kubernetes Service type                                                     | `ClusterIP`                          |
-| `service.clusterIP`                     | Static clusterIP or None for headless services                              | `nil`                                |
+| `service.clusterIP`                     | Static clusterIP or None for headless services                              | `<nil>`                              |
 | `service.externalTrafficPolicy`         | Source IP preservation (only for Service type NodePort and LoadBalancer)    | `Local`                              |
 | `service.loadBalancerSourceRanges`      | Restricts access for LoadBalancer (only for Service type LoadBalancer)      | `[]`                                 |
-| `service.servicename`                   | Custom name for service                                                     | ``                                   |
+| `service.servicename`                   | Custom name for service                                                     | `<nil>`                              |
 | `service.labels`                        | Additional labels for service                                               | `{}`                                 |
 | `serviceMonitor.enabled`                | Enable the ServiceMontor resource to be deployed                            | `false`                              |
 | `serviceMonitor.labels`                 | Labels for the servicemonitor used by the Prometheus Operator               | `{}`                                 |
 | `serviceMonitor.namespace`              | Namespace of the ServiceMonitor resource                                    | `{{ .Release.Namespace }}`           |
 | `serviceMonitor.metricsPath`            | Path to the Chartmuseum metrics path                                        | `/metrics`                           |
-| `serviceMonitor.interval`               | Scrape interval, If not set, the Prometheus default scrape interval is used | `nil`                                |
-| `serviceMonitor.timeout`                | Scrape request timeout. If not set, the Prometheus default timeout is used  | `nil`                                |
+| `serviceMonitor.interval`               | Scrape interval, If not set, the Prometheus default scrape interval is used | `<nil>`                              |
+| `serviceMonitor.timeout`                | Scrape request timeout. If not set, the Prometheus default timeout is used  | `<nil>`                              |
+| `deployment.annotations`                | Additional annotations for deployment                                       | `{}`                                 |
 | `deployment.labels`                     | Additional labels for deployment                                            | `{}`                                 |
 | `podAnnotations`                        | Annotations for pods                                                        | `{}`                                 |
 | `ingress.enabled`                       | Enable ingress controller resource                                          | `false`                              |
 | `ingress.annotations`                   | Ingress annotations                                                         | `{}`                                 |
 | `ingress.labels`                        | Ingress labels                                                              | `{}`                                 |
-| `ingress.hosts[0].name`                 | Hostname for the ingress                                                    | ``                                   |
-| `ingress.hosts[0].path`                 | Path within the url structure                                               | ``                                   |
+| `ingress.hosts[0].name`                 | Hostname for the ingress                                                    | `<nil>`                              |
+| `ingress.hosts[0].path`                 | Path within the url structure                                               | `/`                                  |
 | `ingress.hosts[0].tls `                 | Enable TLS on the ingress host                                              | `false`                              |
-| `ingress.hosts[0].tlsSecret`            | TLS secret to use (must be manually created)                                | ``                                   |
-| `ingress.hosts[0].serviceName`          | The name of the service to route traffic to.                                | `{{ .Values.service.externalPort }}` |
-| `ingress.hosts[0].servicePort`          | The port of the service to route traffic to.                                | `{{ .chartmuseum. }}`                |
-| `ingress.extraPaths[0].path`            | Path within the url structure.                                              | ``                                   |
-| `ingress.extraPaths[0].service`         | The name of the service to route traffic to.                                | ``                                   |
-| `ingress.extraPaths[0].port`            | The port of the service to route traffic to.                                | ``                                   |
+| `ingress.hosts[0].tlsSecret`            | TLS secret to use (must be manually created)                                | `<nil>`                              |
+| `ingress.hosts[0].serviceName`          | The name of the service to route traffic to.                                | `{{ include "chartmuseum.fullname" . }}` |
+| `ingress.hosts[0].servicePort`          | The port of the service to route traffic to.                                | `{{ .Values.service.externalPort }}` |
+| `ingress.extraPaths[0].path`            | Path within the url structure.                                              | `<nil>`                              |
+| `ingress.extraPaths[0].service`         | The name of the service to route traffic to.                                | `<nil>`                              |
+| `ingress.extraPaths[0].port`            | The port of the service to route traffic to.                                | `<nil>`                              |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.
@@ -708,7 +723,7 @@ helm install --name my-chartmuseum stable/chartmuseum \
 
 #### Annotations
 
-For annotations, please see [this document for nginx](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md) and [this document for Traefik](https://docs.traefik.io/configuration/backends/kubernetes/#general-annotations). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
+For annotations, please see [this document for nginx](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md) and [this document for Traefik](https://doc.traefik.io/traefik/v1.7/configuration/backends/kubernetes/#general-annotations). Not all annotations are supported by all ingress controllers, but this document does a good job of indicating which annotation is supported by many popular ingress controllers. Annotations can be set using `ingress.annotations`.
 
 #### Example Ingress configuration
 

--- a/src/chartmuseum/templates/deployment.yaml
+++ b/src/chartmuseum/templates/deployment.yaml
@@ -2,41 +2,31 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
+  {{- with .Values.deployment.annotations }}
   annotations:
-{{ toYaml .Values.deployment.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-{{ include "chartmuseum.labels.standard" . | indent 4 }}
-{{- if .Values.deployment.labels }}
-{{ toYaml .Values.deployment.labels | indent 4 }}
-{{- end }}
+    {{- include "chartmuseum.labels" . | nindent 4 }}
+    {{- if .Values.deployment.labels }}
+    {{- toYaml .Values.deployment.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
-      app: {{ template "chartmuseum.name" . }}
-      release: {{ .Release.Name | quote }}
-{{- if .Values.deployment.labels }}
-{{ toYaml .Values.deployment.labels | indent 6 }}
-{{- end }}
+      {{- include "chartmuseum.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.replicaCount }}
   strategy:
 {{ toYaml .Values.strategy | indent 4 }}
   revisionHistoryLimit: 10
-{{- if .Values.deployment.matchlabes }}
-  selector:
-    matchLabels:
-{{ toYaml .Values.deployment.matchlabels | indent 6 }}
-{{- end }}
   template:
     metadata:
-      name: {{ include "chartmuseum.fullname" . }}
+      {{- with .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.replica.annotations | indent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
-        app: {{ template "chartmuseum.name" . }}
-        release: {{ .Release.Name | quote }}
-{{- if .Values.deployment.labels }}
-{{ toYaml .Values.deployment.labels | indent 8 }}
-{{- end }}
+        {{- include "chartmuseum.selectorLabels" . | nindent 8 }}
     spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: "{{ .Values.priorityClassName }}"
@@ -170,16 +160,11 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- if .Values.deployment.schedulerName }}
-      schedulerName: {{ .Values.deployment.schedulerName }}
-    {{- end -}}
-    {{- if and .Values.serviceAccount.create .Values.serviceAccount.name }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
-    {{- else if .Values.serviceAccount.create }}
-      serviceAccountName: {{ include "chartmuseum.fullname" . }}
-    {{- else if .Values.serviceAccount.name }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
+    {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName }}
     {{- end }}
+      serviceAccountName: {{ include "chartmuseum.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       volumes:
       - name: storage-volume
       {{- if .Values.persistence.enabled }}
@@ -187,23 +172,23 @@ spec:
           claimName: {{ .Values.persistence.existingClaim | default (include "chartmuseum.fullname" .) }}
       {{- else }}
         emptyDir: {}
-      {{- end -}}
+      {{- end }}
       {{ if .Values.gcp.secret.enabled }}
       - name: {{ include "chartmuseum.fullname" . }}-gcp
         secret:
-      {{ if .Values.env.secret.GOOGLE_CREDENTIALS_JSON }}
+      {{- if .Values.env.secret.GOOGLE_CREDENTIALS_JSON }}
           secretName: {{ include "chartmuseum.fullname" . }}
           items:
           - key: GOOGLE_CREDENTIALS_JSON
             path: credentials.json
-      {{ else }}
+      {{- else }}
           secretName: {{ .Values.gcp.secret.name }}
           items:
           - key: {{ .Values.gcp.secret.key }}
             path: credentials.json
-      {{ end }}
-      {{ end }}
-      {{ if .Values.oracle.secret.enabled }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.oracle.secret.enabled }}
       - name: {{ include "chartmuseum.fullname" . }}-oracle
         secret:
           secretName: {{ .Values.oracle.secret.name }}

--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -11,13 +11,15 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
-{{- if .Values.ingress.labels }}
-{{ toYaml .Values.ingress.labels | indent 4 }}
-{{- end }}
-{{ include "chartmuseum.labels.standard" . | indent 4 }}
+    {{- include "chartmuseum.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   rules:
   {{- range .Values.ingress.hosts }}

--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -3,10 +3,12 @@
 {{- $serviceName := include "chartmuseum.fullname" . -}}
 {{- $ingressExtraPaths := .Values.ingress.extraPaths -}}
 ---
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: extensions/v1beta1
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- end }}
 kind: Ingress
 metadata:
@@ -29,21 +31,45 @@ spec:
       {{- range $ingressExtraPaths }}
       - path: {{ default "/" .path | quote }}
         backend:
-        {{- if $.Values.service.servicename }}
+        {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          {{- if $.Values.service.servicename }}
           serviceName: {{ $.Values.service.servicename }}
-        {{- else }}
+          {{- else }}
           serviceName: {{ default $serviceName .service }}
-        {{- end }}
+          {{- end }}
           servicePort: {{ default $servicePort .port }}
+        {{- else }}
+          service:
+            {{- if $.Values.service.servicename }}
+            name: {{ $.Values.service.servicename }}
+            {{- else }}
+            name: {{ default $serviceName .service }}
+            {{- end }}
+            port:
+              number: {{ default $servicePort .port }}
+        pathType: ImplementationSpecific
+        {{- end }}
       {{- end }}
       - path: {{ default "/" .path | quote }}
         backend:
-        {{- if $.Values.service.servicename }}
+        {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          {{- if $.Values.service.servicename }}
           serviceName: {{ $.Values.service.servicename }}
-        {{- else }}
+          {{- else }}
           serviceName: {{ default $serviceName .service }}
-        {{- end }}
+          {{- end }}
           servicePort: {{ default $servicePort .servicePort }}
+        {{- else }}
+          service:
+            {{- if $.Values.service.servicename }}
+            name: {{ $.Values.service.servicename }}
+            {{- else }}
+            name: {{ default $serviceName .service }}
+            {{- end }}
+            port:
+              number: {{ default $servicePort .port }}
+        pathType: ImplementationSpecific
+        {{- end }}
   {{- end }}
   tls:
   {{- range .Values.ingress.hosts }}

--- a/src/chartmuseum/templates/pv.yaml
+++ b/src/chartmuseum/templates/pv.yaml
@@ -2,14 +2,9 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-{{- if .Values.persistence.pv.pvname }}
-  name: {{ .Values.persistence.pv.pvname }}
-{{- else }}
-  name: {{ include "chartmuseum.fullname" . }}
-{{- end }}
+  name: {{ .Values.persistence.pv.pvname | default (include "chartmuseum.fullname" .) }}
   labels:
-    app: {{ include "chartmuseum.fullname" . }}
-    release: {{ .Release.Name | quote }}
+    {{- include "chartmuseum.selectorLabels" . | nindent 4 }}
 spec:
   capacity:
     storage: {{ .Values.persistence.pv.capacity.storage }}

--- a/src/chartmuseum/templates/pvc.yaml
+++ b/src/chartmuseum/templates/pvc.yaml
@@ -4,11 +4,10 @@ apiVersion: v1
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
   labels:
-    app: {{ include "chartmuseum.fullname" . }}
-    release: {{ .Release.Name | quote }}
-{{- if .Values.persistence.labels }}
-{{ toYaml .Values.persistence.labels | indent 4 }}
-{{- end }}
+    {{- include "chartmuseum.selectorLabels" . | nindent 4 }}
+    {{- with .Values.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/src/chartmuseum/templates/secret.yaml
+++ b/src/chartmuseum/templates/secret.yaml
@@ -4,10 +4,10 @@ kind: Secret
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
   labels:
-{{- if .Values.secret.labels }}
-{{ toYaml .Values.secret.labels | indent 4 }}
-{{- end }}
-{{ include "chartmuseum.labels.standard" . | indent 4 }}
+    {{- include "chartmuseum.labels" . | nindent 4 }}
+    {{- with .Values.secret.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 type: Opaque
 data:
 {{- range $name, $value := .Values.env.secret }}

--- a/src/chartmuseum/templates/service.yaml
+++ b/src/chartmuseum/templates/service.yaml
@@ -1,20 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.service.servicename }}
-  name: {{ .Values.service.servicename }}
-{{- else }}
-  name: {{ include "chartmuseum.fullname" . }}
-{{- end }}
-  labels:
-{{ include "chartmuseum.labels.standard" . | indent 4 }}
-{{- if .Values.service.labels }}
-{{ toYaml .Values.service.labels | indent 4 }}
-{{- end }}
-{{- if .Values.service.annotations }}
+  name: {{ .Values.service.servicename | default (include "chartmuseum.fullname" .) }}
+  {{- with .Values.service.annotations }}
   annotations:
-{{ toYaml .Values.service.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml . | indent 4 }}
+  {{- end }}
+  labels:
+    {{- include "chartmuseum.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   {{- if (or (eq .Values.service.type "LoadBalancer") (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)))) }}
@@ -41,5 +37,4 @@ spec:
     protocol: TCP
     name: http
   selector:
-    app: {{ template "chartmuseum.name" . }}
-    release: {{ .Release.Name | quote }}
+    {{- include "chartmuseum.selectorLabels" . | nindent 4 }}

--- a/src/chartmuseum/templates/serviceaccount.yaml
+++ b/src/chartmuseum/templates/serviceaccount.yaml
@@ -3,15 +3,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-{{- if .Values.serviceAccount.name }}
-  name: {{ .Values.serviceAccount.name }}
-{{- else }}
-  name: {{ include "chartmuseum.fullname" . }}
-{{- end }}
-  labels:
-{{ include "chartmuseum.labels.standard" . | indent 4 }}
-{{- if .Values.serviceAccount.annotations }}
+  name: {{ include "chartmuseum.serviceAccountName" . }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "chartmuseum.labels" . | nindent 4 }}
 {{- end }}
-{{- end -}}

--- a/src/chartmuseum/templates/servicemonitor.yaml
+++ b/src/chartmuseum/templates/servicemonitor.yaml
@@ -2,15 +2,13 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.serviceMonitor.labels }}
+  name: {{ include "chartmuseum.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
   labels:
-{{ toYaml .Values.serviceMonitor.labels | indent 4 }}
-{{- end }}
-  name: {{ template "chartmuseum.fullname" . }}
-  namespace: {{ .Release.Namespace }}
-{{- if .Values.serviceMonitor.namespace }}
-  namespace: {{ .Values.serviceMonitor.namespace }}
-{{- end }}
+    {{- include "chartmuseum.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   endpoints:
   - targetPort: 8080
@@ -23,12 +21,11 @@ spec:
 {{- if .Values.serviceMonitor.timeout }}
     scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
 {{- end }}
-  jobLabel: {{ template "chartmuseum.fullname" . }}
+  jobLabel: {{ include "chartmuseum.fullname" . }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "chartmuseum.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "chartmuseum.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/src/chartmuseum/values.yaml
+++ b/src/chartmuseum/values.yaml
@@ -1,4 +1,4 @@
-extraArgs:
+extraArgs: []
   # - --storage-timestamp-tolerance 1s
 replicaCount: 1
 strategy:
@@ -94,7 +94,7 @@ env:
     AUTH_REALM:
     # auth service used for bearer auth
     AUTH_SERVICE:
-  field:
+  field: {}
     # POD_IP: status.podIP
   secret:
     # username for basic http authentication
@@ -118,21 +118,25 @@ env:
     # Redis requirepass server configuration
     CACHE_REDIS_PASSWORD:
 
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName:
+
 deployment:
-  # Define scheduler name. Use of 'default' if empty
-  schedulerName: ""
   ## Chartmuseum Deployment annotations
   annotations: {}
   #   name: value
   labels: {}
   #   name: value
-  matchlabels: {}
-  #   name: value
-replica:
-  ## Chartmuseum Replicas annotations
-  annotations: {}
-  ## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
-  #   iam.amazonaws.com/role: role-arn
+
+## Pod annotations
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+## Read more about kube2iam to provide access to s3 https://github.com/jtblin/kube2iam
+##
+podAnnotations: {}
+  # iam.amazonaws.com/role: role-arn
+
 service:
   servicename:
   type: ClusterIP
@@ -178,7 +182,8 @@ probes:
 
 serviceAccount:
   create: false
-  # name:
+  name: ""
+  automountServiceAccountToken: false
   ## Annotations for the Service Account
   annotations: {}
 
@@ -209,8 +214,8 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
   labels: {}
+    # name: value
   path: /storage
-  #   name: value
   ## A manually managed Persistent Volume and Claim
   ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound
@@ -254,33 +259,33 @@ volumePermissions:
 ## Ingress for load balancer
 ingress:
   enabled: false
-## Chartmuseum Ingress labels
-##
-#   labels:
-#     dns: "route53"
+  ## Chartmuseum Ingress labels
+  ##
+  labels: {}
+    # dns: "route53"
 
-## Chartmuseum Ingress annotations
-##
-#   annotations:
-#     kubernetes.io/ingress.class: nginx
-#     kubernetes.io/tls-acme: "true"
+  ## Chartmuseum Ingress annotations
+  ##
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
 
-## Chartmuseum Ingress hostnames
-## Must be provided if Ingress is enabled
-##
-#  hosts:
-#    - name: chartmuseum.domain1.com
-#      path: /
-#      tls: false
-#    - name: chartmuseum.domain2.com
-#      path: /
-#
-#      ## Set this to true in order to enable TLS on the ingress record
-#      tls: true
-#
-#      ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
-#      ## Secrets must be added manually to the namespace
-#      tlsSecret: chartmuseum.domain2-tls
+  ## Chartmuseum Ingress hostnames
+  ## Must be provided if Ingress is enabled
+  ##
+  hosts: []
+    # - name: chartmuseum.domain1.com
+    #   path: /
+    #   tls: false
+    # - name: chartmuseum.domain2.com
+    #   path: /
+    #
+    #   ## Set this to true in order to enable TLS on the ingress record
+    #   tls: true
+    #
+    #   ## If TLS is set to true, you must declare what secret will store the key/certificate for TLS
+    #   ## Secrets must be added manually to the namespace
+    #   tlsSecret: chartmuseum.domain2-tls
 
 # Adding secrets to tiller is not a great option, so If you want to use an existing
 # secret that contains the json file, you can use the following entries


### PR DESCRIPTION
Since helm2 is EOL for a while now, lets change the chart to `apiVersion: v2`.

While here, I updated several other things:
* Update the `_helpers.tpl` to prepare the next point (new labels)
* Labels are updated to follow the official Kubernetes [label recommendations](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
* Move `schedulerName` from `deployment.` to toplevel to followup README (also it doesn't make sense below the `deployment` tree since this field relates to PodSpec)
* Ingress now supports the v1 Spec
* Update docs (README), mainly document missing default values