### PR TITLE
Https liveness and readiness probes

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.1.0
+version: 3.1.1
 appVersion: 0.13.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/templates/deployment.yaml
+++ b/src/chartmuseum/templates/deployment.yaml
@@ -120,11 +120,17 @@ spec:
           httpGet:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
+            {{- if and .Values.env.open.TLS_CERT .Values.env.open.TLS_KEY }}
+            scheme: HTTPS
+            {{- end }}
 {{ toYaml .Values.probes.liveness | indent 10 }}
         readinessProbe:
           httpGet:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
+            {{- if and .Values.env.open.TLS_CERT .Values.env.open.TLS_KEY }}
+            scheme: HTTPS
+            {{- end }}
 {{ toYaml .Values.probes.readiness | indent 10 }}
         volumeMounts:
 {{- if eq .Values.env.open.STORAGE "local" }}


### PR DESCRIPTION
allow for https readiness/liveness probes if TLS_CERT and TLS_KEY env variables are specified