### PR TITLE
Fixing rendering of annotations in the svc template

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.1.0
+version: 3.1.1
 appVersion: 0.13.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/templates/service.yaml
+++ b/src/chartmuseum/templates/service.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.service.servicename | default (include "chartmuseum.fullname" .) }}
   {{- with .Values.service.annotations }}
   annotations:
-    {{ toYaml . | indent 4 }}
+  {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "chartmuseum.labels" . | nindent 4 }}


### PR DESCRIPTION
With the current chart, if you add multiple annotations under the `service.annotations` section there will be incorrect indentation. Example:
```
service:
  annotations:
    my-test: "something"
    my-other-test: "something-else"
```

will yield:
```
# Source: chartmuseum/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-chartmuseum
  annotations:
        my-other-test: something-else
    my-test: something
```

This PR fixes that problem with using the `nindent` function:
```
# Source: chartmuseum/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-chartmuseum
  annotations:
    my-other-test: something-else
    my-test: something
```