### PR TITLE
Add volumeName if found to pvc

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.3.0
+version: 3.4.1
 appVersion: 0.13.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/templates/pvc.yaml
+++ b/src/chartmuseum/templates/pvc.yaml
@@ -20,7 +20,8 @@ spec:
 {{- else }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
 {{- end }}
-{{- else if and .Values.persistence.volumeName (.Values.persistence.pv.enabled) }}
+{{- if .Values.persistence.volumeName }}
   volumeName: "{{ .Values.persistence.volumeName }}"
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Issue (why)
volumeName for pvc is added and tight to pv, hence it is only added if pv is enabled.
This is causing issues if pv is already created and want to create a pvc with this existing volume

## Solution
volumeName for pvc should be independent from pv and added if found.

## Test
using `helm template .` the below is generated successfully:
```
---
# Source: chartmuseum/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: RELEASE-NAME-chartmuseum
  labels:
    helm.sh/chart: chartmuseum-3.3.0
    app.kubernetes.io/name: chartmuseum
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "0.13.1"
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
---
# Source: chartmuseum/templates/pvc.yaml
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: RELEASE-NAME-chartmuseum
  labels:
    app.kubernetes.io/name: chartmuseum
    app.kubernetes.io/instance: RELEASE-NAME
spec:
  accessModes:
    - "ReadWriteOnce"
  resources:
    requests:
      storage: "8Gi"
  storageClassName: "ssg"
  volumeName: "test"              # <============= added volumeName when found without generating pv
---
# Source: chartmuseum/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: RELEASE-NAME-chartmuseum
  labels:
    helm.sh/chart: chartmuseum-3.3.0
    app.kubernetes.io/name: chartmuseum
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "0.13.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
  - port: 8080
    targetPort: http
    protocol: TCP
    name: http
  selector:
    app.kubernetes.io/name: chartmuseum
    app.kubernetes.io/instance: RELEASE-NAME
---
# Source: chartmuseum/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: RELEASE-NAME-chartmuseum
  labels:
    helm.sh/chart: chartmuseum-3.3.0
    app.kubernetes.io/name: chartmuseum
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/version: "0.13.1"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: chartmuseum
      app.kubernetes.io/instance: RELEASE-NAME
  replicas: 1
  strategy:
    rollingUpdate:
      maxUnavailable: 0
    type: RollingUpdate
  revisionHistoryLimit: 10
  template:
    metadata:
      labels:
        app.kubernetes.io/name: chartmuseum
        app.kubernetes.io/instance: RELEASE-NAME
    spec:
      securityContext:
        fsGroup: 1000      
      containers:
      - name: chartmuseum
        image: ghcr.io/helm/chartmuseum:v0.13.1
        imagePullPolicy: IfNotPresent
        securityContext:
          {}
        env:
        - name: "CHART_POST_FORM_FIELD_NAME"
          value: "chart"
        - name: "DISABLE_API"
          value: "true"
        - name: "DISABLE_METRICS"
          value: "true"
        - name: "LOG_JSON"
          value: "true"
        - name: "PROV_POST_FORM_FIELD_NAME"
          value: "prov"
        - name: "STORAGE"
          value: "local"
        args:
        - --port=8080
        - --storage-local-rootdir=/storage
        ports:
        - name: http
          containerPort: 8080
        livenessProbe:
          httpGet:
            path: /health
            port: http
          failureThreshold: 3
          initialDelaySeconds: 5
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        readinessProbe:
          httpGet:
            path: /health
            port: http
          failureThreshold: 3
          initialDelaySeconds: 5
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 1
        volumeMounts:
        - mountPath: /storage
          name: storage-volume
      serviceAccountName: default
      automountServiceAccountToken: false
      volumes:
      - name: storage-volume
        persistentVolumeClaim:
          claimName: RELEASE-NAME-chartmuseum
```