### PR TITLE
feat: add support for extra volumes and extra volume mounts

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.3.0
+version: 3.4.0
 appVersion: 0.13.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -195,6 +195,8 @@ their default values. See values.yaml for all available options.
 | `serviceMonitor.timeout`                | Scrape request timeout. If not set, the Prometheus default timeout is used  | `<nil>`                              |
 | `deployment.annotations`                | Additional annotations for deployment                                       | `{}`                                 |
 | `deployment.labels`                     | Additional labels for deployment                                            | `{}`                                 |
+| `deployment.extraVolumes`               | Additional volumes for deployment                                           | `[]`                                 |
+| `deployment.extraVolumeMounts`          | Additional volumes to mount in container for deployment                     | `[]`                                 |
 | `podAnnotations`                        | Annotations for pods                                                        | `{}`                                 |
 | `ingress.enabled`                       | Enable ingress controller resource                                          | `false`                              |
 | `ingress.annotations`                   | Ingress annotations                                                         | `{}`                                 |

--- a/src/chartmuseum/templates/deployment.yaml
+++ b/src/chartmuseum/templates/deployment.yaml
@@ -127,6 +127,9 @@ spec:
             port: http
 {{ toYaml .Values.probes.readiness | indent 10 }}
         volumeMounts:
+{{- if .Values.deployment.extraVolumeMounts }}
+        {{- toYaml .Values.deployment.extraVolumeMounts | nindent 8 }}
+{{- end }}
 {{- if eq .Values.env.open.STORAGE "local" }}
         - mountPath: {{ .Values.persistence.path }}
           name: storage-volume
@@ -166,6 +169,9 @@ spec:
       serviceAccountName: {{ include "chartmuseum.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
       volumes:
+      {{- if .Values.deployment.extraVolumes }}
+      {{- toYaml .Values.deployment.extraVolumes | nindent 6 }}
+      {{- end }}
       - name: storage-volume
       {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/src/chartmuseum/values.yaml
+++ b/src/chartmuseum/values.yaml
@@ -129,6 +129,10 @@ deployment:
   #   name: value
   labels: {}
   #   name: value
+  # additional volumes
+  extraVolumes: []
+  # additional volumes to mount
+  extraVolumeMounts: []
 
 ## Pod annotations
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/


### PR DESCRIPTION
This PR adds support for extra volumes and extra volume mounts.

This is useful to enable IRSA on AWS without pod identity webhook.
IRSA requires an extra volume, an extra volume mount and env variables to be set so that aws sdk can make use of `AssumeRoleWithWebIdentity`.
