### PR TITLE
Support defining scheme of liveness and readiness checks

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.4.1
+version: 3.5.0
 appVersion: 0.13.1
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -166,11 +166,13 @@ their default values. See values.yaml for all available options.
 | `probes.liveness.timeoutSeconds`        | Number of seconds after which the liveness probe times out                  | `1`                                  |
 | `probes.liveness.successThreshold`      | Minimum consecutive successes for the liveness probe                        | `1`                                  |
 | `probes.liveness.failureThreshold`      | Minimum consecutive failures for the liveness probe                         | `3`                                  |
+| `probes.livenessHttpGetConfig.scheme`   | Scheme to use for the liveness probe                                        | `HTTP`                               |
 | `probes.readiness.initialDelaySeconds`  | Delay before readiness probe is initiated                                   | `5`                                  |
 | `probes.readiness.periodSeconds`        | How often (in seconds) to perform the readiness probe                       | `10`                                 |
 | `probes.readiness.timeoutSeconds`       | Number of seconds after which the readiness probe times out                 | `1`                                  |
 | `probes.readiness.successThreshold`     | Minimum consecutive successes for the readiness probe                       | `1`                                  |
 | `probes.readiness.failureThreshold`     | Minimum consecutive failures for the readiness probe                        | `3`                                  |
+| `probes.readinessHttpGetConfig.scheme`  | Scheme to use for the readiness probe                                       | `HTTP`                               |
 | `gcp.secret.enabled`                    | Flag for the GCP service account                                            | `false`                              |
 | `gcp.secret.name`                       | Secret name for the GCP json file                                           | `<nil>`                              |
 | `gcp.secret.key`                        | Secret key for te GCP json file                                             | `credentials.json`                   |

--- a/src/chartmuseum/templates/deployment.yaml
+++ b/src/chartmuseum/templates/deployment.yaml
@@ -120,11 +120,13 @@ spec:
           httpGet:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
+{{ toYaml .Values.probes.livenessHttpGetConfig | indent 12 }}
 {{ toYaml .Values.probes.liveness | indent 10 }}
         readinessProbe:
           httpGet:
             path: {{ .Values.env.open.CONTEXT_PATH }}/health
             port: http
+{{ toYaml .Values.probes.readinessHttpGetConfig | indent 12 }}
 {{ toYaml .Values.probes.readiness | indent 10 }}
         volumeMounts:
 {{- if .Values.deployment.extraVolumeMounts }}

--- a/src/chartmuseum/values.yaml
+++ b/src/chartmuseum/values.yaml
@@ -180,12 +180,16 @@ probes:
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
+  livenessHttpGetConfig:
+    scheme: HTTP
   readiness:
     initialDelaySeconds: 5
     periodSeconds: 10
     timeoutSeconds: 1
     successThreshold: 1
     failureThreshold: 3
+  readinessHttpGetConfig:
+    scheme: HTTP
 
 serviceAccount:
   create: false


### PR DESCRIPTION
This PR adds support for setting the scheme of readiness and liveliness checks.

In our use-case we can't use ingress rules for TLS as we use chartmuseum to host helm charts during bootstrap and  also need chartmuseum itself to use TLS as we want to enable authz for API endpoints that allow updating/uploading charts. User/pass should never be transmitted in plaintext even between ingress and the pod.

I could add TLS support with help `extraVolumes`, `extraVolumeMounts` and `extraArgs` but ATM there is no way to adjust liveness and readiness checks to support TLS connection to chartmuseum. This PR fixes that.