### PR TITLE
Support string type in ingress service port and pathType in ingress path

### DIFF
--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -49,7 +49,11 @@ spec:
             name: {{ default $serviceName .service }}
             {{- end }}
             port:
+              {{- if kindIs "string" (default $servicePort .port) }}
+              name: {{ default $servicePort .port }}
+              {{- else }}
               number: {{ default $servicePort .port }}
+              {{- end }}
         pathType: {{ default "ImplementationSpecific" .pathType | quote }}
         {{- end }}
       {{- end }}
@@ -70,7 +74,11 @@ spec:
             name: {{ default $serviceName .service }}
             {{- end }}
             port:
+             {{- if kindIs "string" (default $servicePort .port) }}
+              name: {{ default $servicePort .port }}
+              {{- else }}
               number: {{ default $servicePort .port }}
+              {{- end }}
         pathType: {{ default "ImplementationSpecific" .pathType | quote }}
         {{- end }}
   {{- end }}

--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -50,7 +50,7 @@ spec:
             {{- end }}
             port:
               number: {{ default $servicePort .port }}
-        pathType: ImplementationSpecific
+        pathType: {{ default "ImplementationSpecific" .pathType | quote }}
         {{- end }}
       {{- end }}
       - path: {{ default "/" .path | quote }}
@@ -71,7 +71,7 @@ spec:
             {{- end }}
             port:
               number: {{ default $servicePort .port }}
-        pathType: ImplementationSpecific
+        pathType: {{ default "ImplementationSpecific" .pathType | quote }}
         {{- end }}
   {{- end }}
   tls:


### PR DESCRIPTION
Support string type in ingress service port and pathType in ingress path to work with Application Load Balancer.

It is required to support the ssl-redirect and a different pathType (ex. "Prefix"):
```
spec:
  rules:
  - host: chartmuseum.domain.com
    http:
      paths:
      - path: "/"
        backend:
          service:
            name: ssl-redirect
            port:
              name: use-annotation
        pathType: "Prefix"

```