### PR TITLE
Fix strategy type support for Recreate

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.7.0
+version: 3.7.1
 appVersion: 0.14.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/values.yaml
+++ b/src/chartmuseum/values.yaml
@@ -3,8 +3,6 @@ extraArgs: []
 replicaCount: 1
 strategy:
   type: RollingUpdate
-  rollingUpdate:
-    maxUnavailable: 0
 image:
   repository: ghcr.io/helm/chartmuseum
   tag: v0.14.0


### PR DESCRIPTION
The block `rollingUpdate` is incompatible with the `Recreate` strategy type and is not overridable.

Partially fixes #4 