### PR TITLE
docs: Add note about DISABLE_API

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.6.2
+version: 3.6.3
 appVersion: 0.14.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -54,8 +54,10 @@ Please also see https://github.com/helm/chartmuseum
 ## Configuration
 
 By default this chart will not have persistent storage, and the API service
-will be *DISABLED*.  This protects against unauthorized access to the API
+will be *DISABLED* (`env.open.DISABLE_API=true`).  This protects against unauthorized access to the API
 with default configuration values.
+
+> You must set `env.open.DISABLE_API=false` if you intend to use the ChartMuseum API.
 
 In addition, by default, pod `securityContext.fsGroup` is set to `1000`. This
 is the user/group that the ChartMuseum container runs as, and is used to


### PR DESCRIPTION
This is a follow up on https://github.com/helm/chartmuseum/issues/566. I just wanted to add a bit of a more noticeable warning about the API being disabled by default. 