### PR TITLE
Support for Ingress ALB `ssl-redirect`

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.7.1
+version: 3.7.2
 appVersion: 0.14.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- $servicePort := .Values.service.externalPort -}}
-{{- $serviceName := include "chartmuseum.fullname" . -}}
+{{- $serviceName := default (include "chartmuseum.fullname" .) .Values.service.servicename -}}
 {{- $ingressExtraPaths := .Values.ingress.extraPaths -}}
 ---
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
@@ -35,19 +35,11 @@ spec:
       - path: {{ default "/" .path | quote }}
         backend:
         {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-          {{- if $.Values.service.servicename }}
-          serviceName: {{ $.Values.service.servicename }}
-          {{- else }}
           serviceName: {{ default $serviceName .service }}
-          {{- end }}
           servicePort: {{ default $servicePort .port }}
         {{- else }}
           service:
-            {{- if $.Values.service.servicename }}
-            name: {{ $.Values.service.servicename }}
-            {{- else }}
             name: {{ default $serviceName .service }}
-            {{- end }}
             port:
               {{- if kindIs "string" (default $servicePort .port) }}
               name: {{ default $servicePort .port }}
@@ -60,19 +52,11 @@ spec:
       - path: {{ default "/" .path | quote }}
         backend:
         {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-          {{- if $.Values.service.servicename }}
-          serviceName: {{ $.Values.service.servicename }}
-          {{- else }}
           serviceName: {{ default $serviceName .service }}
-          {{- end }}
           servicePort: {{ default $servicePort .servicePort }}
         {{- else }}
           service:
-            {{- if $.Values.service.servicename }}
-            name: {{ $.Values.service.servicename }}
-            {{- else }}
             name: {{ default $serviceName .service }}
-            {{- end }}
             port:
               {{- if kindIs "string" (default $servicePort .port) }}
               name: {{ default $servicePort .port }}

--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -49,7 +49,11 @@ spec:
             name: {{ default $serviceName .service }}
             {{- end }}
             port:
+              {{- if kindIs "string" (default $servicePort .port) }}
+              name: {{ default $servicePort .port }}
+              {{- else }}
               number: {{ default $servicePort .port }}
+              {{- end }}
         pathType: {{ default $.Values.ingress.pathType .pathType }}
         {{- end }}
       {{- end }}
@@ -70,7 +74,11 @@ spec:
             name: {{ default $serviceName .service }}
             {{- end }}
             port:
+              {{- if kindIs "string" (default $servicePort .port) }}
+              name: {{ default $servicePort .port }}
+              {{- else }}
               number: {{ default $servicePort .port }}
+              {{- end }}
         pathType: {{ $.Values.ingress.pathType }}
         {{- end }}
   {{- end }}


### PR DESCRIPTION
Fixes #43
Originally #37

From @mike7515:

> Support type string in ingress service port and pathType in ingress path to work with Application Load Balancer.
>
> It is required to support the ssl-redirect

This adds the ability to specify a `port.name` when setting a `port:` to a `string` value.
In addition, it prevents `service.servicename` from overriding a path's local `service:` name.