### PR TITLE
feat: bump image to v0.15.0

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.8.0
-appVersion: 0.14.0
+version: 3.9.0
+appVersion: 0.15.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg
 keywords:

--- a/src/chartmuseum/README.md
+++ b/src/chartmuseum/README.md
@@ -140,7 +140,7 @@ their default values. See values.yaml for all available options.
 | `env.open.DEBUG`                        | Show debug messages                                                         | `false`                              |
 | `env.open.LOG_JSON`                     | Output structured logs in JSON                                              | `true`                               |
 | `env.open.DISABLE_STATEFILES`           | Disable use of index-cache.yaml                                             | `false`                              |
-| `env.open.DISABLE_METRICS`              | Disable Prometheus metrics                                                  | `true`                               |
+| `env.open.ENABLE_METRICS`               | Enable Prometheus metrics                                                   | `false`                              |
 | `env.open.DISABLE_API`                  | Disable all routes prefixed with /api                                       | `true`                               |
 | `env.open.ALLOW_OVERWRITE`              | Allow chart versions to be re-uploaded                                      | `false`                              |
 | `env.open.CHART_URL`                    | Absolute url for .tgzs in index.yaml                                        | `<nil>`                              |

--- a/src/chartmuseum/values.yaml
+++ b/src/chartmuseum/values.yaml
@@ -5,7 +5,7 @@ strategy:
   type: RollingUpdate
 image:
   repository: ghcr.io/helm/chartmuseum
-  tag: v0.14.0
+  tag: v0.15.0
   pullPolicy: IfNotPresent
 secret:
   labels: {}
@@ -66,8 +66,8 @@ env:
     LOG_JSON: true
     # disable use of index-cache.yaml
     DISABLE_STATEFILES: false
-    # disable Prometheus metrics
-    DISABLE_METRICS: true
+    # enable Prometheus metrics
+    ENABLE_METRICS: false
     # disable all routes prefixed with /api
     DISABLE_API: true
     # allow chart versions to be re-uploaded


### PR DESCRIPTION
`v0.15.0` hasn't been cut yet so that will need to happen first before merging. 

This commit bumps the image to `v0.15.0` and also includes the changes from https://github.com/chartmuseum/charts/pull/38 which require `v0.15.0`. 
