### PR TITLE
feat: add support for common labels in helm charts

### DIFF
--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.9.0
+version: 3.9.1
 appVersion: 0.15.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/Chart.yaml
+++ b/src/chartmuseum/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Host your own Helm Chart Repository
 name: chartmuseum
-version: 3.9.1
+version: 3.9.2
 appVersion: 0.15.0
 home: https://github.com/helm/chartmuseum
 icon: https://raw.githubusercontent.com/chartmuseum/charts/main/logo.jpg

--- a/src/chartmuseum/templates/_helpers.tpl
+++ b/src/chartmuseum/templates/_helpers.tpl
@@ -54,6 +54,9 @@ Selector labels
 {{- define "chartmuseum.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "chartmuseum.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/src/chartmuseum/templates/_helpers.tpl
+++ b/src/chartmuseum/templates/_helpers.tpl
@@ -45,6 +45,9 @@ helm.sh/chart: {{ include "chartmuseum.chart" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -54,9 +57,6 @@ Selector labels
 {{- define "chartmuseum.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "chartmuseum.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Values.commonLabels}}
-{{ toYaml .Values.commonLabels }}
-{{- end }}
 {{- end }}
 
 {{/*

--- a/src/chartmuseum/templates/pv.yaml
+++ b/src/chartmuseum/templates/pv.yaml
@@ -4,6 +4,7 @@ kind: PersistentVolume
 metadata:
   name: {{ .Values.persistence.pv.pvname | default (include "chartmuseum.fullname" .) }}
   labels:
+    {{- include "chartmuseum.labels" . | nindent 4 }}
     {{- include "chartmuseum.selectorLabels" . | nindent 4 }}
 spec:
   capacity:

--- a/src/chartmuseum/templates/pvc.yaml
+++ b/src/chartmuseum/templates/pvc.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 metadata:
   name: {{ include "chartmuseum.fullname" . }}
   labels:
+    {{- include "chartmuseum.labels" . | nindent 4 }}
     {{- include "chartmuseum.selectorLabels" . | nindent 4 }}
     {{- with .Values.persistence.labels }}
     {{- toYaml . | nindent 4 }}

--- a/src/chartmuseum/values.yaml
+++ b/src/chartmuseum/values.yaml
@@ -9,6 +9,10 @@ image:
   pullPolicy: IfNotPresent
 secret:
   labels: {}
+## Labels to apply to all resources
+##
+commonLabels: {}
+# team_name: dev
 env:
   open:
     # storage backend, can be one of: local, alibaba, amazon, google, microsoft, oracle


### PR DESCRIPTION
Signed-off-by: Jean-Baptiste DONNETTE <jean-baptiste.donnette@payfit.com>

When we used a policies manager as Kyverno, it's usefull to be able to add a common labels on all resources created by the chart in order to respect the policy.

