### PR TITLE
Support string `name` in service `port:` & allow `service:` name override

### DIFF
--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 {{- $servicePort := .Values.service.externalPort -}}
-{{- $serviceName := include "chartmuseum.fullname" . -}}
+{{- $serviceName := default (include "chartmuseum.fullname" .) .Values.service.servicename -}}
 {{- $ingressExtraPaths := .Values.ingress.extraPaths -}}
 ---
 {{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
@@ -35,19 +35,11 @@ spec:
       - path: {{ default "/" .path | quote }}
         backend:
         {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-          {{- if $.Values.service.servicename }}
-          serviceName: {{ $.Values.service.servicename }}
-          {{- else }}
           serviceName: {{ default $serviceName .service }}
-          {{- end }}
           servicePort: {{ default $servicePort .port }}
         {{- else }}
           service:
-            {{- if $.Values.service.servicename }}
-            name: {{ $.Values.service.servicename }}
-            {{- else }}
             name: {{ default $serviceName .service }}
-            {{- end }}
             port:
               {{- if kindIs "string" (default $servicePort .port) }}
               name: {{ default $servicePort .port }}
@@ -60,19 +52,11 @@ spec:
       - path: {{ default "/" .path | quote }}
         backend:
         {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-          {{- if $.Values.service.servicename }}
-          serviceName: {{ $.Values.service.servicename }}
-          {{- else }}
           serviceName: {{ default $serviceName .service }}
-          {{- end }}
           servicePort: {{ default $servicePort .servicePort }}
         {{- else }}
           service:
-            {{- if $.Values.service.servicename }}
-            name: {{ $.Values.service.servicename }}
-            {{- else }}
             name: {{ default $serviceName .service }}
-            {{- end }}
             port:
               {{- if kindIs "string" (default $servicePort .port) }}
               name: {{ default $servicePort .port }}

--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -49,7 +49,11 @@ spec:
             name: {{ default $serviceName .service }}
             {{- end }}
             port:
+              {{- if kindIs "string" (default $servicePort .port) }}
+              name: {{ default $servicePort .port }}
+              {{- else }}
               number: {{ default $servicePort .port }}
+              {{- end }}
         pathType: {{ default $.Values.ingress.pathType .pathType }}
         {{- end }}
       {{- end }}
@@ -70,7 +74,11 @@ spec:
             name: {{ default $serviceName .service }}
             {{- end }}
             port:
+              {{- if kindIs "string" (default $servicePort .port) }}
+              name: {{ default $servicePort .port }}
+              {{- else }}
               number: {{ default $servicePort .port }}
+              {{- end }}
         pathType: {{ $.Values.ingress.pathType }}
         {{- end }}
   {{- end }}


### PR DESCRIPTION
Fixes #43

- Support string `name` in service `port:` (from #37, rebased to latest)
- Allow `service:` name override for individual services

Example below uses `service: ssl-redirect` with `port: use-annotation`.
In the current helm release, this doesn't work for two reasons:

1. `service.servicename: helm` supersedes the individual service names, even when they're specified.
2. No support for `port.name` & string port values.

```yaml
service:
  servicename: helm

  ## Chartmuseum Ingress hostnames
  ## Must be provided if Ingress is enabled
  hosts:
    - name: helm.example.com
      path: /*
      service: helm

      ## Set this to true in order to enable TLS on the ingress record
      tls: false

  extraPaths:
    - path: /*
      service: ssl-redirect
      port: use-annotation
```