### PR TITLE
Update ingress.yaml to use v3 kube version check syntax

### DIFF
--- a/src/chartmuseum/templates/ingress.yaml
+++ b/src/chartmuseum/templates/ingress.yaml
@@ -3,9 +3,9 @@
 {{- $serviceName := include "chartmuseum.fullname" . -}}
 {{- $ingressExtraPaths := .Values.ingress.extraPaths -}}
 ---
-{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
-{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion }}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: networking.k8s.io/v1
@@ -34,7 +34,7 @@ spec:
       {{- range $ingressExtraPaths }}
       - path: {{ default "/" .path | quote }}
         backend:
-        {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.Version }}
           {{- if $.Values.service.servicename }}
           serviceName: {{ $.Values.service.servicename }}
           {{- else }}
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       - path: {{ default "/" .path | quote }}
         backend:
-        {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+        {{- if semverCompare "<1.19-0" $.Capabilities.KubeVersion.Version }}
           {{- if $.Values.service.servicename }}
           serviceName: {{ $.Values.service.servicename }}
           {{- else }}


### PR DESCRIPTION
With Helm 3.x, `.Capabilities.KubeVersion.GitVersion` is deprecated (see https://github.com/helm/helm/blob/master/pkg/chartutil/capabilities.go#L60). To avert future breakage, the chart should use `.Capabilities.KubeVersion.Version` in ingress.yaml when selecting which kubernetes version to pick the apiVersion for the ingress.